### PR TITLE
Update to 0.1.4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ https://wordpress.org/support/theme/the-bootstrap-blog
 
 * Added: support JS
   - Remove the `no-js` class from body if JS is supported
+* Removed: unnecessary comment_reply_link filter hook
+  - fixed by new patch (51081)
 
 ### 0.1.4.3
 *Released: July 24, 2021*

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 Summary:           | The Bootstrap Blog
 -------------------|----------------
 Contributors:      | [mrpauloen](https://profiles.wordpress.org/mrpauloen/)
-Version:           | 0.1.4.3
+Version:           | 0.1.4.4
 Requires at least: | 5.5
 Tested up to:      | 5.8
-Requires PHP:	   | 7.0
+Requires PHP:  	   | 7.0
 License:           | GPLv2 or later
 License URI:       | http://www.gnu.org/licenses/gpl-2.0.html
 Tags:              | two-columns, custom-menu, custom-background, right-sidebar, custom-header, featured-images, sticky-post, threaded-comments, translation-ready, blog
@@ -147,6 +147,12 @@ If there is something you don't understand, please use the support forum:
 https://wordpress.org/support/theme/the-bootstrap-blog
 
 ## Changelog
+
+### 0.1.4.4
+*Released: November 14, 2021
+
+* Added: support JS
+  - Remove the `no-js` class from body if JS is supported
 
 ### 0.1.4.3
 *Released: July 24, 2021*

--- a/functions.php
+++ b/functions.php
@@ -467,63 +467,6 @@ function the_bootstrap_blog__filter__post_thumbnail_html( $html ) {
 	}
 }
 
-/**
- * This filter is explained in this ticket:
- * @link https://core.trac.wordpress.org/ticket/51189
- *
- * @since The Bootstrap Blog 0.1.2
- */
-
-add_filter( 'comment_reply_link', 'the_bootstrap_blog__filter__comment_reply_link', 10, 4 );
-function the_bootstrap_blog__filter__comment_reply_link( $link, $args, $comment, $post ){
-	global $wp_rewrite;
-
-	$page = get_page_of_comment( $comment->comment_ID );
-
-// Copied from get_comment_reply_link() function
-	if ( get_option( 'comment_registration' ) && ! is_user_logged_in() ) {
-		$link = sprintf(
-			'<a rel="nofollow" class="comment-reply-login small" href="%s">%s</a>',
-			esc_url( wp_login_url( get_permalink() ) ),
-			$args['login_text']
-		);
-	} else {
-		$data_attributes = array(
-			'commentid'      => $comment->comment_ID,
-			'postid'         => $post->ID,
-			'belowelement'   => $args['add_below'] . '-' . $comment->comment_ID,
-			'respondelement' => $args['respond_id'],
-			'replyto'        => sprintf( $args['reply_to_text'], $comment->comment_author ),
-		);
-
-		$data_attribute_string = '';
-
-		foreach ( $data_attributes as $name => $value ) {
-			$data_attribute_string .= " data-${name}=\"" . esc_attr( $value ) . '"';
-		}
-
-		$data_attribute_string = trim( $data_attribute_string );
-
-		$link = sprintf(
-			"<a rel='nofollow' class='comment-reply-link small' href='%s' %s aria-label='%s'>%s</a>",
-			esc_url(
-				add_query_arg(
-					array(
-						'replytocom'      => $comment->comment_ID,
-						'unapproved'      => false,
-						'moderation-hash' => false,
-					),
-					get_permalink( $post->ID ) . $wp_rewrite->comments_pagination_base . '-' . $page . '/'
-				)
-			) . '#' . $args['respond_id'],
-			$data_attribute_string,
-			esc_attr( sprintf( $args['reply_to_text'], $comment->comment_author ) ),
-			$args['reply_text']
-		);
-	}
-	 return $args['before'] . $link . $args['after'];
-}
-
 /** Default excerpt length **/
 
 function the_bootstrap_blog__default_excerpt_length(){

--- a/functions.php
+++ b/functions.php
@@ -252,6 +252,18 @@ function the_bootstrap_blog__action__skip_link() {
 }
 
 /**
+ * Remove the `no-js` class from body if JS is supported.
+ *
+ * @since The Bootstrap Blog 0.1.4.4
+ *
+ * @return void
+ */
+function the_bootstrap_blog__action__supports_js() {
+	echo '<script>document.body.classList.remove("no-js");</script>';
+}
+add_action( 'wp_footer', 'the_bootstrap_blog__action__supports_js' );
+
+/**
  * Register widget area.
  *
  * @link https://developer.wordpress.org/themes/functionality/sidebars/#registering-a-sidebar

--- a/header.php
+++ b/header.php
@@ -10,7 +10,7 @@
  */
 
 ?><!DOCTYPE html>
-<html  class="no-js" <?php language_attributes(); ?>>
+<html <?php language_attributes(); ?>>
   <head>
 	<meta charset="<?php bloginfo( 'charset' ); ?>">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
@@ -20,7 +20,7 @@
 	<?php wp_head(); ?>
 
   </head>
-<body <?php body_class(); ?>>
+<body <?php body_class('no-js'); ?>>
 
   <?php wp_body_open(); ?>
 

--- a/inc/customizer/js/the_bootstrap_blog_autoheight_textarea.js
+++ b/inc/customizer/js/the_bootstrap_blog_autoheight_textarea.js
@@ -22,7 +22,7 @@ jQuery( document ).ready( function( $ ){
 	$('#comment').trigger('input');
 
 	$('#comment').focus(function(){
-		 $('#form-input').collapse();
+		 $('#form-input').collapse('show');
 	});
 
 	$('[data-toggle="tooltip"]').tooltip();

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 == The Bootstrap Blog ==
 Requires at least: 5.5
 Tested up to: 5.8
-Version: 0.1.4.3
+Version: 0.1.4.4
 License: GPL-2.0-or-later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: two-columns, custom-menu, custom-background, right-sidebar, custom-header, featured-images, sticky-post, threaded-comments, translation-ready, blog
@@ -79,16 +79,8 @@ Activiation and Use
 ** Licence URI: https://creativecommons.org/licenses/by-sa/4.0/
 **
 
-*! screenshot.png
-** Copyright:   https://stocksnap.io/
-** @link:       https://stocksnap.io/photo/typewriter-vintage-8E6502A3BC
-** Author:      Sergey Zolkin
-** Author URI:  https://stocksnap.io/author/276
-** License:     CC0
-** Licence URI: https://stocksnap.io/license
-
 *!
-** Bootstrap v4.5.3 (https://getbootstrap.com/)
+** Bootstrap v4.6 (https://getbootstrap.com/)
 ** Copyright 2011-2020 The Bootstrap Authors
 ** Copyright 2011-2020 Twitter, Inc.
 ** Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
@@ -147,8 +139,15 @@ https://wordpress.org/support/theme/the-bootstrap-blog
 
 == Changelog ==
 
+=== 0.1.4.4 ===
+*Released: November 14, 2021*
+
+* Added: support JS
+** Remove the no-js class from body if JS is supported
+
+
 === 0.1.4.3 ===
-*Released: July 24, 2021
+*Released: July 24, 2021*
 
 * Fixed small issue with Akismet hidden textarea field
 

--- a/readme.txt
+++ b/readme.txt
@@ -144,6 +144,8 @@ https://wordpress.org/support/theme/the-bootstrap-blog
 
 * Added: support JS
 ** Remove the no-js class from body if JS is supported
+* Removed: unnecessary comment_reply_link filter hook
+** fixed by new patch (51081)
 
 
 === 0.1.4.3 ===

--- a/style.css
+++ b/style.css
@@ -107,6 +107,12 @@ h6, .h6 {
     color: #fff!important;
 }
 /*
+ * Override Bootstrap's default collapse behavior if JS is not supported.
+ */
+.no-js .collapse:not(.show) {
+    display: inherit;
+}
+/*
  * Masthead for nav
  */
 .blog-masthead {


### PR DESCRIPTION
Support JS

Derived from TwentyTwentyOne an JS mechanism.

Remove the `no-js` class from body if JS is supported.
Show collapsed elements (in this case a comments textarea) when JS is disabled.

BTW: I removed unnecessary comment_reply_link filter hook which was fixed by new patch. 
